### PR TITLE
Patch 1

### DIFF
--- a/src/game/server/account.cpp
+++ b/src/game/server/account.cpp
@@ -316,7 +316,7 @@ bool CAccChatHandler::HandleChatMsg(class CPlayer *pPlayer, const char *pMsg)
 				if (pAcc->Head()->m_FailCount > 0)
 				{
 					char aTime[2][32];
-					str_timestamp_at(aTime[0], sizeof (aTime[0]), pAcc->Head()->m_FailDate[0]);
+					str_timestamp_at(aTime[0], sizeof (aTime[0]), pAcc->Head()->m_FailDate[0]); /* <-- CRASH --> */
 					if (pAcc->Head()->m_FailCount > 1)
 					{
 						str_timestamp_at(aTime[1], sizeof (aTime[1]), pAcc->Head()->m_FailDate[1]);


### PR DESCRIPTION
I build your account system on Windows XP. When I register then everything works fine, but when I leave the server and try to login it crashes at the marked point (I put some dbg_msg to see where it crashes) On Linux everything works fine.
Debug log: (gdb is crap on windows, even when compiling with gcc)
Program received signal SIGTRAP, Trace/breakpoint trap.
0x00449e9a in ?? ()
(gdb) backtrace
#0  0x00449e9a in ?? ()
#1  0x00449c3e in ?? ()
#2  0x00417de9 in ?? ()
#3  0x004243ea in ?? ()
#4  0x00424c7b in ?? ()
#5  0x0042bd56 in ?? ()
#6  0x0041bae7 in ?? ()
#7  0x0041c272 in ?? ()
#8  0x0041cd73 in ?? ()
#9  0x0041e185 in ?? ()
#10 0x0044ec29 in ?? ()
#11 0x0044eaef in ?? ()
#12 0x7c817077 in RegisterWaitForInputIdle ()

   from C:\WINXP\system32\kernel32.dll
#13 0x00000000 in ?? ()

And here a error shown in a dialog box: http://boto-x.tk/files/crash.PNG
Edit: Fu i made a pull request xD How can i add a comment to a line?
